### PR TITLE
fix: add unique(email, event_id) constraint

### DIFF
--- a/@app/server/__tests__/helpers.ts
+++ b/@app/server/__tests__/helpers.ts
@@ -373,7 +373,8 @@ export const runGraphQLQuery = async (
       req: any
     }
   ) => void | ExecutionResult | Promise<void | ExecutionResult> = () => {}, // Place test assertions in this function
-  rollback = true
+  rollback = true,
+  takeSnapshot = true
 ) => {
   if (!ctx) throw new Error("No ctx!")
   const { schema, rootPgPool, options } = ctx
@@ -482,7 +483,9 @@ export const runGraphQLQuery = async (
         })
 
         // You don't have to keep this, I just like knowing when things change!
-        expect(sanitize(result)).toMatchSnapshot()
+        if (takeSnapshot) {
+          expect(sanitize(result)).toMatchSnapshot()
+        }
 
         return checkResult == null ? result : checkResult
       } finally {

--- a/@app/server/__tests__/mutations/__snapshots__/createRegistration.test.ts.snap
+++ b/@app/server/__tests__/mutations/__snapshots__/createRegistration.test.ts.snap
@@ -34,6 +34,14 @@ Object {
 }
 `;
 
+exports[`CreateRegistration can't create a registration if a registration already exists with the same email 1`] = `
+Object {
+  "data": Object {
+    "claimRegistrationToken": "[id-1]",
+  },
+}
+`;
+
 exports[`CreateRegistration can't create a registration if first or last name contains spaces 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
Allow only a single registration per email address for a specific event